### PR TITLE
Update New-OSDTattoo.ps1

### DIFF
--- a/New-OSDTattoo.ps1
+++ b/New-OSDTattoo.ps1
@@ -938,22 +938,22 @@ if (!(Test-Path $LogFile)){
             }
             "WMI" {
                 "Tattooing: $($Tatoo.Name) with value: $($Tatoo.value) --> in WMI." >> $LogFile
-                New-OSDTattoo -Root $Root -Name $($Tatoo.Name) -Value $($Tatoo.value) -wmi
+                New-OSDTattoo -Root $Root -PropertyName $($Tatoo.Name) -PropertyValue $($Tatoo.value) -wmi
                 break
             }
             "Registry"{
                 "Tattooing: $($Tatoo.Name) with value: $($Tatoo.value) --> in Registry." >> $LogFile
-                New-OSDTattoo -Root $Root -Name $($Tatoo.Name) -Value $($Tatoo.value) -Registry
+                New-OSDTattoo -Root $Root -PropertyName $($Tatoo.Name) -PropertyValue $($Tatoo.value) -Registry
                 Break
             }
             "EnvironmentVariable"{
                 "Tattooing: $($Tatoo.Name) with value: $($Tatoo.value) --> in environment variables." >> $LogFile
-                New-OSDTattoo -Root $Root -Name $($Tatoo.Name) -Value $($Tatoo.value) -EnvironmentVariable
+                New-OSDTattoo -Root $Root -PropertyName $($Tatoo.Name) -PropertyValue $($Tatoo.value) -EnvironmentVariable
                 break
             }
             default{
                 "Tattooing: $($Tatoo.Name) with value: $($Tatoo.value) --> in WMI, Registry and environment variables.">> $LogFile
-                New-OSDTattoo -Root $Root -Name $($Tatoo.Name) -Value $($Tatoo.value) -All
+                New-OSDTattoo -Root $Root -PropertyName $($Tatoo.Name) -PropertyValue $($Tatoo.value) -All
                 break
                 
             }


### PR DESCRIPTION
This is to resolve an issue where only the -ALL parameter will work. These changes fix the incorrect New-OSDTatto parameter calls in the script arguments switch statement. They have been changed from -Name and -Value with -PropertyName and -PropertyValue, respectively.